### PR TITLE
Send questionnaire responses in confirmation email

### DIFF
--- a/packages/telemed-intake/app/src/theme/harbor/i18n-en.json
+++ b/packages/telemed-intake/app/src/theme/harbor/i18n-en.json
@@ -53,10 +53,10 @@
   "contactSupport": {
     "needHelp": "Need help?",
     "support": "Support",
-    "callUs": "Call us: <strong>(123) 456-7890</strong>",
+    "callUs": "Email us: <strong>careteam@harbor.co</strong>",
     "hours": "Sunday-Saturday 10am-10pm ET.",
-    "moreInfo": "For wait times or more information:",
-    "moreInfoLink": "https://ottehr.com",
+    "moreInfo": "For more information:",
+    "moreInfoLink": "https://harbor.gorgias.help/en-US/articles/remote-night-nanny-168557",
     "moreInfoLinkText": "Click Here",
     "emergency": "If this is an emergency, please call 911."
   },
@@ -128,7 +128,8 @@
   "pastVisits": {
     "visits": "Visits",
     "visitDetails": "Visit Details",
-    "backToHome": "Back to homepage"
+    "backToHome": "Back to homepage",
+    "noVisits": "No visits"
   },
   "patientInfo": {
     "title": "About the patient",
@@ -198,11 +199,11 @@
   "thankYou": {
     "title": "Thank you for choosing Harbor",
     "description": "We look forward to helping you soon!",
-    "checkInBookedTime": "Your check-in time is booked for:",
-    "confirmationMessage": "You will receive a confirmation email and SMS for your upcoming check-in time shortly. If you need to make any changes, please follow the instructions in the email.",
+    "checkInBookedTime": "Your consultation is booked for:",
+    "confirmationMessage": "One of our providers will reach out to you at the scheduled time. You will receive a confirmation email and SMS for your upcoming consultation shortly. If you need to make any changes, please follow the instructions in the email.",
     "insurancePolicy": "All patients that present with commercial insurance will be required to leave a credit card on file. More details on our financial policy can be found ",
     "insurancePolicyLinkText": "here",
-    "contactUs": "If you have any questions or concerns, please call our team at: <strong>(123) 456-7890</strong>."
+    "contactUs": "If you have any questions or concerns, please email at: <strong>careteam@harbor.co</strong>."
   },
   "visitDetails": {
     "visitId": "Visit ID: {{visitId}}",
@@ -211,15 +212,15 @@
   "waitingRoom": {
     "title": "Congratulations!",
     "imgAlt": "",
-    "subtext": "You're one step closer to resting easy. Our care team will reach out to book a 30 minute consultation prior to your trial.",
+    "subtext": "You're one step closer to resting easy. Our care team will reach out for your 30 minute consultation.",
     "approxWaitTime": "Approx. wait time - {{estimatedTime}}",
     "fallbackWaitTime": "...mins",
     "callSettingsTitle": "Call settings & Test",
     "callSettingsSubtext": "Audio, video, microphone",
     "leaveRoomTitle": "Leave waiting room",
     "leaveRoomSubtext": "We will notify you once the call starts",
-    "cancelVisitTitle": "Cancel visit",
-    "cancelVisitSubtext": "You will not be charged if you cancel the visit"
+    "cancelVisitTitle": "Cancel consultation",
+    "cancelVisitSubtext": "You will not be charged if you cancel the consultation"
   },
   "welcome": {
     "title": "Harbor",
@@ -228,8 +229,8 @@
     "scheduleNotAvailable": "The schedule \"{{slug}}\" is not available",
     "visitServiceNotAvailable": "The service \"{{visitService}}\" is not available",
     "scheduleError": "There was an error getting the schedule. Please refresh and if you still get errors contact us.",
-    "message": "Your free extended trial (10 nights) to Harbor's Remote Night Nanny is based on Harbor's availability, your family's eligibility, and is on a first come first serve basis. Free extended trial must be redeemed prior to Dec 31st, 2024.",
-    "html": "<p><em>Harbor's Remote Night Nanny is 5 consecutive nights from Sunday pm through Friday am.</em></p>",
+    "message": "Schedule your Consultation now.",
+    "html": "<p><em>Your free extended trial to Harbor's Remote Night Nanny must be redeemed prior to Dec 31st, 2024.</em></p>",
     "dateError": {
       "title": "Please select a date and time",
       "description": "To continue, please select an available appointment."

--- a/packages/telemed-intake/zambdas/src/paperwork/create-paperwork/questionnaireResponse.ts
+++ b/packages/telemed-intake/zambdas/src/paperwork/create-paperwork/questionnaireResponse.ts
@@ -1,0 +1,88 @@
+import { Questionnaire, QuestionnaireItem, QuestionnaireResponse } from 'fhir/r4';
+
+export interface Question {
+  question: string;
+  answer?: string | undefined;
+  answers?: Question[];
+}
+
+const typeToValueKeyMap = new Map([
+  ['string', 'valueString'],
+  ['text', 'valueString'],
+  ['choice', 'valueString'],
+  ['boolean', 'valueBoolean'],
+  ['integer', 'valueInteger'],
+  ['date', 'valueDate'],
+  ['decimal', 'valueDecimal'],
+  ['time', 'valueTime'],
+  ['dateTime', 'valueDateTime'],
+  ['open-choice', 'valueString'],
+  ['attachment', 'valueAttachment'],
+  ['reference', 'valueReference'],
+  ['quantity', 'valueQuantity'],
+  ['coding', 'valueCoding'],
+]);
+
+type QuestionnaireItemWithGroup = QuestionnaireItem & { groupLinkId?: string; groupTitle?: string };
+
+export const simplifyQuestionnaireResponse = (
+  response: QuestionnaireResponse,
+  questionnaire: Questionnaire,
+): Question[] => {
+  const questionnaireTitlesMap = new Map<string, QuestionnaireItemWithGroup>(
+    questionnaire.item?.flatMap((question) =>
+      question.type == 'group' && question?.item
+        ? question!.item.map((item) => [
+            item.linkId,
+            { ...item, groupLinkId: question.linkId, groupTitle: question.text },
+          ])
+        : [[question.linkId, question]],
+    ),
+  );
+
+  const summary: Question[] =
+    response.item?.reduce((accumulator, item) => {
+      let acc = accumulator;
+      const formQuestion = questionnaireTitlesMap.get(item.linkId);
+
+      // determine where to push the final question object
+      // If it's a member of a question grouping, push it to the group answers list
+      if (formQuestion?.groupLinkId && formQuestion?.groupTitle) {
+        let groupQuestion = accumulator.find((it) => it.question === formQuestion.groupTitle);
+        if (!groupQuestion) {
+          // Add the group to the accumulator if it doesn't already exist
+          groupQuestion = { question: formQuestion.groupTitle, answers: [] };
+          accumulator.push(groupQuestion);
+        }
+        // final answer object will be pushed to the group answers list
+        acc = groupQuestion!.answers as Question[];
+      }
+
+      const question = formQuestion?.text || item.linkId;
+      let answer = '';
+      if (item.answer) {
+        answer += item.answer
+          .map((it) => {
+            if (formQuestion?.type) {
+              const key = typeToValueKeyMap.get(formQuestion.type);
+              if (key) {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                return it[key];
+              }
+            }
+            return '';
+          })
+          .join(',');
+      }
+
+      acc.push({
+        question: question,
+        answer: answer,
+      });
+
+      return accumulator;
+    }, [] as Question[]) || [];
+
+  return summary;
+};

--- a/packages/telemed-intake/zambdas/src/shared/communication.ts
+++ b/packages/telemed-intake/zambdas/src/shared/communication.ts
@@ -3,6 +3,11 @@ import { Secrets, SecretsKeys, getSecret, createMessagingClient, getOptionalSecr
 import i18n from './i18n';
 import { HealthcareService, Location, Practitioner } from 'fhir/r4';
 
+interface QuestionResponse {
+  question: string;
+  answer?: string | undefined;
+  answers?: QuestionResponse[];
+}
 export interface ConfirmationEmailInput {
   email: string;
   firstName: string | undefined;
@@ -11,6 +16,7 @@ export interface ConfirmationEmailInput {
   secrets: Secrets | null;
   location: Location;
   appointmentType: string;
+  questionnaireResponse: QuestionResponse[];
 }
 
 export const sendConfirmationEmail = async (input: ConfirmationEmailInput): Promise<void> => {
@@ -30,6 +36,7 @@ export const sendConfirmationEmail = async (input: ConfirmationEmailInput): Prom
     appointmentType,
     paperworkUrl: `${WEBSITE_URL}/paperwork/${appointmentID}`,
     checkInUrl: `${WEBSITE_URL}/waiting-room?appointment_id=${appointmentID}`,
+    questionnaireResponse: input.questionnaireResponse,
   };
   await sendEmail(email, templateId, subject, templateInformation, secrets);
 };
@@ -148,6 +155,7 @@ export async function sendConfirmationMessages(
   appointmentType: string,
   verifiedPhoneNumber: string | undefined,
   token: string,
+  questionnaireResponse: QuestionResponse[],
 ): Promise<void> {
   if (email) {
     await sendConfirmationEmail({
@@ -158,6 +166,7 @@ export async function sendConfirmationMessages(
       secrets,
       location,
       appointmentType,
+      questionnaireResponse,
     });
   } else {
     console.log('email undefined');


### PR DESCRIPTION
Both the patient and careteam receive emails with a summary of the questionnaire response

plus, modify verbiage to clarify this is a consultation

Will look something like:
<img width="667" alt="Screenshot 2024-10-07 at 1 46 07 PM" src="https://github.com/user-attachments/assets/fe373287-924a-46f7-baec-36b664e32c3c">
